### PR TITLE
test: write test that uses same BeanListener to connect to many beans

### DIFF
--- a/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBeanManager.java
+++ b/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBeanManager.java
@@ -12,7 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration tests for the BeanManager.
- * Note: This requires an actual bean nearby to pass!
+ *
+ * Prerequisites:
+ *  - Bean within range
+ *  - Android device connected over USB
+ *
  */
 public class TestBeanManager extends AndroidTestCase {
 


### PR DESCRIPTION
Related to Issue #13 

This test uses the same `BeanListener` to connect to multiple beans.  This method is not advised but should still be tested.  There is no "clean" way to determine which bean connected within the context of the `BeanListener.onConnected()` callback ... however the following test makes a less than ideal attempt at it.