### PR TITLE
Fix issue with reading the wrong scratch bank

### DIFF
--- a/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBean.java
+++ b/sdk/src/androidTest/java/com/punchthrough/bean/sdk/TestBean.java
@@ -9,6 +9,7 @@ import com.punchthrough.bean.sdk.message.BeanError;
 import com.punchthrough.bean.sdk.message.Callback;
 import com.punchthrough.bean.sdk.message.DeviceInfo;
 import com.punchthrough.bean.sdk.message.ScratchBank;
+import com.punchthrough.bean.sdk.message.ScratchData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -120,6 +121,95 @@ public class TestBean extends AndroidTestCase {
         });
         deviceInfoLatch.await();
         assertThat(testState.get("device_info")).isNotNull();
+
+        if (bean.isConnected()) {
+            bean.disconnect();
+        }
+    }
+
+    public void testBeanReadWriteScratchBank() throws InterruptedException {
+        Bean bean = this.getBeans(1).get(0);
+        final CountDownLatch connectionLatch = new CountDownLatch(1);
+        final HashMap testState = new HashMap();
+        testState.put("connected", false);
+
+        BeanListener beanListener = new BeanListener() {
+            @Override
+            public void onConnected() {
+                testState.put("connected", true);
+                connectionLatch.countDown();
+
+            }
+
+            @Override
+            public void onConnectionFailed() {
+                fail("Connection failed!");
+            }
+
+            @Override
+            public void onDisconnected() {
+            }
+
+            @Override
+            public void onSerialMessageReceived(byte[] data) {
+            }
+
+            @Override
+            public void onScratchValueChanged(ScratchBank bank, byte[] value) {
+            }
+
+            @Override
+            public void onError(BeanError error) {
+                fail(error.toString());
+            }
+        };
+
+        bean.connect(getContext(), beanListener);
+        connectionLatch.await();
+        assertThat(testState.get("connected")).isEqualTo(true);
+
+        // write to BANK_1 and BANK_5
+
+        bean.setScratchData(ScratchBank.BANK_1, new byte[]{11, 12, 13});
+        bean.setScratchData(ScratchBank.BANK_5, new byte[]{51, 52, 53});
+
+        // read BANK_1
+
+        final CountDownLatch scratch1Latch = new CountDownLatch(1);
+        bean.readScratchData(ScratchBank.BANK_1, new Callback<ScratchData>() {
+            @Override
+            public void onResult(ScratchData result) {
+                testState.put("scratch1", result);
+                scratch1Latch.countDown();
+            }
+        });
+
+        scratch1Latch.await();
+
+        ScratchData scratch1 = (ScratchData)testState.get("scratch1");
+        assertThat(scratch1.number()).isEqualTo(1);
+        assertThat(scratch1.data()[0]).isEqualTo((byte)11);
+        assertThat(scratch1.data()[1]).isEqualTo((byte)12);
+        assertThat(scratch1.data()[2]).isEqualTo((byte)13);
+
+        // read BANK_5
+
+        final CountDownLatch scratch5Latch = new CountDownLatch(1);
+        bean.readScratchData(ScratchBank.BANK_5, new Callback<ScratchData>() {
+            @Override
+            public void onResult(ScratchData result) {
+                testState.put("scratch5", result);
+                scratch5Latch.countDown();
+            }
+        });
+
+        scratch5Latch.await();
+
+        ScratchData scratch5 = (ScratchData)testState.get("scratch5");
+        assertThat(scratch5.number()).isEqualTo(5);
+        assertThat(scratch5.data()[0]).isEqualTo((byte)51);
+        assertThat(scratch5.data()[1]).isEqualTo((byte)52);
+        assertThat(scratch5.data()[2]).isEqualTo((byte)53);
 
         if (bean.isConnected()) {
             bean.disconnect();

--- a/sdk/src/androidTest/java/com/punchthrough/bean/sdk/message/ScratchBankTest.java
+++ b/sdk/src/androidTest/java/com/punchthrough/bean/sdk/message/ScratchBankTest.java
@@ -5,11 +5,11 @@ import android.test.AndroidTestCase;
 public class ScratchBankTest extends AndroidTestCase {
 
     public void testBankRawNumbers() {
-        assertTrue(ScratchBank.BANK_1.getRawValue() == 0);
-        assertTrue(ScratchBank.BANK_2.getRawValue() == 1);
-        assertTrue(ScratchBank.BANK_3.getRawValue() == 2);
-        assertTrue(ScratchBank.BANK_4.getRawValue() == 3);
-        assertTrue(ScratchBank.BANK_5.getRawValue() == 4);
+        assertTrue(ScratchBank.BANK_1.getRawValue() == 1);
+        assertTrue(ScratchBank.BANK_2.getRawValue() == 2);
+        assertTrue(ScratchBank.BANK_3.getRawValue() == 3);
+        assertTrue(ScratchBank.BANK_4.getRawValue() == 4);
+        assertTrue(ScratchBank.BANK_5.getRawValue() == 5);
     }
 
 }

--- a/sdk/src/main/java/com/punchthrough/bean/sdk/message/ScratchBank.java
+++ b/sdk/src/main/java/com/punchthrough/bean/sdk/message/ScratchBank.java
@@ -8,7 +8,7 @@ import com.punchthrough.bean.sdk.internal.utility.EnumParse;
  * Represents the scratch bank data is being sent to/read from.
  */
 public enum ScratchBank implements EnumParse.ParsableEnum {
-    BANK_1(0), BANK_2(1), BANK_3(2), BANK_4(3), BANK_5(4);
+    BANK_1(1), BANK_2(2), BANK_3(3), BANK_4(4), BANK_5(5);
 
     private final int value;
 

--- a/sdk/src/main/java/com/punchthrough/bean/sdk/message/ScratchData.java
+++ b/sdk/src/main/java/com/punchthrough/bean/sdk/message/ScratchData.java
@@ -37,7 +37,7 @@ import okio.Buffer;
 @AutoParcel
 public abstract class ScratchData implements Parcelable, Message {
     public static ScratchData fromPayload(Buffer buffer) {
-        return new AutoParcel_ScratchData((buffer.readByte() & 0xff) - 1, buffer.readByteArray());
+        return new AutoParcel_ScratchData((buffer.readByte() & 0xff), buffer.readByteArray());
     }
 
     public static ScratchData create(ScratchBank bank, byte[] data) {
@@ -68,7 +68,7 @@ public abstract class ScratchData implements Parcelable, Message {
     @Override
     public byte[] toPayload() {
         Buffer buffer = new Buffer();
-        buffer.writeByte((number() + 1) & 0xff);
+        buffer.writeByte((number()) & 0xff);
         buffer.write(data());
         return buffer.readByteArray();
     }


### PR DESCRIPTION
There's an issue in the SDK where a call to Bean.readScratchData will always return data from the requested bank number minus one. For example, Bean.readScratchData(ScratchBank.BANK_2) will return the data for scratch bank 1 and so forth. This PR fixes this issue and also adds a unit test for writing and reading to scratch banks.